### PR TITLE
Update to script.js: download data from a URL rather than passing as a string

### DIFF
--- a/browserview/script.js
+++ b/browserview/script.js
@@ -9,10 +9,28 @@ const chart = bb.generate({
   bindto: ".chart"
 });
 
-var response = Papa.parse("https://storage.googleapis.com/waterloo-region-data-visualization-tools/reported_crime_data.csv", {
-	download: true,
-	header : true
-})
+// Function to download a CSV from a remote server into a string
+// Based on: https://stackoverflow.com/questions/30192153/getting-a-remote-csv-file-and-putting-it-into-a-variable
+function getCSV(file) {
+	var rawFile = new XMLHttpRequest();
+	var allText;
+
+	rawFile.open("GET", file, false);
+	rawFile.onreadystatechange = function () {
+		if(rawFile.readyState === 4)
+			if(rawFile.status === 200 || rawFile.status == 0)
+				allText = rawFile.responseText;
+	};
+
+	rawFile.send();
+	return allText;
+}
+
+data_csv = getCSV(file = "https://storage.googleapis.com/waterloo-region-data-visualization-tools/reported_crime_data.csv")
+
+var response = Papa.parse(data_csv, {
+	header: true
+});
 
 // Group data by violation type and statistic
 let data = {};


### PR DESCRIPTION
I think I found a solution to the comment about finding a better way to embed the data. Using a URL in my Google Cloud Storage bucket will allow me to write the data prep code so that the file is automatically updated whenever I change the data prep process. It also allows the script.js file to be smaller.